### PR TITLE
Price item graph

### DIFF
--- a/app/coin/[id]/page.tsx
+++ b/app/coin/[id]/page.tsx
@@ -167,7 +167,7 @@ const CoinPage = ({ params }: { params: { id: string } }) => {
       </div>
       {coin && (
         <div className="w-full h-[330px] rounded-2xl flex gap-5 mt-5">
-          <div className="w-1/2 dark:bg-gray-900 bg-white rounded-2xl p-7 flex flex-col">
+          <div className="w-1/2 dark:bg-[#0c101c] bg-white rounded-2xl p-7 flex flex-col">
             <h1 className="text-2xl">Market</h1>
             <div className="flex justify-between items-center mb-2">
               <h1 className="text-[#afafaf] text-sm">MARKET CAP</h1>

--- a/components/CoinBarGraph/index.tsx
+++ b/components/CoinBarGraph/index.tsx
@@ -1,0 +1,91 @@
+import { SelectedCoin } from "@/interfaces/selectedcoin.interface";
+import { labelFormatter } from "@/redux/features/dateFormatter";
+import formatNumber from "@/utils/formatNumber";
+import { Bar } from "react-chartjs-2";
+
+const options = {
+  responsive: true,
+  tooltip: { enabled: true },
+  maintainAspectRatio: false,
+  plugins: {
+    tooltip: {
+      enabled: true,
+      mode: "index",
+      intersect: false,
+      callbacks: {
+        label: function (tooltipItem: any) {
+          let value = tooltipItem.dataset.data[tooltipItem.dataIndex];
+          value =
+            value < 10
+              ? value.toPrecision(7)
+              : value.toFixed(2).toLocaleString();
+          const coinName = tooltipItem.dataset.label;
+          return `${
+            coinName.charAt(0).toUpperCase() + coinName.slice(1).toLowerCase()
+          }: ${formatNumber(value)}`;
+        },
+        labelColor: function (tooltipItem: any) {
+          const colors = [
+            "rgba(174, 139, 245, 1)",
+            "rgba(255, 139, 245, 1)",
+            "rgba(253, 186, 116, 1)",
+          ];
+          return {
+            borderRadius: 2,
+            backgroundColor:
+              colors[tooltipItem.datasetIndex] || "rgba(174, 139, 245, 1)",
+          };
+        },
+      },
+    },
+  },
+  scales: {
+    x: {
+      grid: { display: false },
+      ticks: {
+        display: true,
+        color: "grey",
+        maxTicksLimit: 10,
+        font: {
+          size: 10,
+        },
+        align: "inner",
+      },
+      border: { display: true },
+      stacked: true,
+    },
+    y: { display: false },
+  },
+  pointRadius: 0,
+  borderWidth: 0,
+};
+
+const CoinBarGraph = ({
+  coins,
+  days,
+}: {
+  coins: SelectedCoin[];
+  days: string;
+}) => {
+  const data = {
+    labels: labelFormatter(coins[0].volumeLabels, days),
+    datasets: coins.map((coin, index) => ({
+      data: coin.total_volumes,
+      label: coin.id,
+      borderColor: options.plugins.tooltip.callbacks.labelColor({
+        datasetIndex: index,
+      }).backgroundColor,
+      backgroundColor: options.plugins.tooltip.callbacks.labelColor({
+        datasetIndex: index,
+      }).backgroundColor,
+      borderWidth: 8,
+      pointRadius: 0,
+      fill: true,
+      tension: 0.8,
+    })),
+  };
+
+  return <Bar options={options as any} data={data as any} />;
+};
+
+export default CoinBarGraph;

--- a/components/CoinGraphChart/index.tsx
+++ b/components/CoinGraphChart/index.tsx
@@ -51,12 +51,18 @@ const options = {
             value < 10
               ? value.toPrecision(7)
               : value.toFixed(2).toLocaleString();
-          return value;
+          return formatNumber(value);
         },
-        labelColor: function () {
+        labelColor: function (tooltipItem: any) {
+          const colors = [
+            "rgba(174, 139, 245, 1)", // Color for the first coin
+            "rgba(255, 139, 245, 1)", // Color for the second coin
+            "rgba(253, 186, 116, 1)", // Color for the third coin
+          ];
           return {
             borderRadius: 2,
-            backgroundColor: "rgba(159, 122, 234)",
+            backgroundColor:
+              colors[tooltipItem.datasetIndex] || "rgba(159, 122, 234)",
           };
         },
       },
@@ -64,35 +70,17 @@ const options = {
   },
   scales: {
     x: {
-      grid: {
-        display: false,
-      },
+      grid: { display: false },
       ticks: {
         display: true,
         color: "grey",
         maxTicksLimit: 10,
         align: "inner",
       },
-      border: {
-        display: true,
-      },
+      border: { display: true },
       stacked: true,
     },
-    y: {
-      display: false,
-    },
-    "y-axis-1": {
-      display: false,
-      beginAtZero: false,
-    },
-    "y-axis-2": {
-      display: false,
-      beginAtZero: false,
-    },
-    "y-axis-3": {
-      display: false,
-      beginAtZero: false,
-    },
+    y: { display: false },
   },
   pointRadius: 0,
   borderWidth: 0,
@@ -127,36 +115,19 @@ const CoinLineGraph = ({
   const [shouldRender, setShouldRender] = useState(false);
   const data = {
     labels: labelFormatter(coins[0].priceLabels, days),
-    datasets: [
-      {
-        data: coins[0].prices,
-        borderColor: "rgba(174, 139, 245)",
-        backgroundColor: getBackgroundColor,
-        borderWidth: 1,
-        pointRadius: 0,
-        fill: true,
-        tension: 0.8,
-      },
-      {
-        data: coins[1]?.prices || [],
-        borderColor: "rgba(255, 139, 245)",
-        backgroundColor: getBackgroundColor,
-        borderWidth: 1,
-        pointRadius: 0,
-        fill: true,
-        tension: 0.8,
-      },
-      {
-        data: coins[2]?.prices || [],
-        borderColor: "rgba(255, 255, 245)",
-        backgroundColor: getBackgroundColor,
-        borderWidth: 1,
-        pointRadius: 0,
-        fill: true,
-        tension: 0.8,
-      },
-    ],
+    datasets: coins.map((coin, index) => ({
+      data: coin.prices,
+      borderColor: options.plugins.tooltip.callbacks.labelColor({
+        datasetIndex: index,
+      }).backgroundColor,
+      backgroundColor: getBackgroundColor,
+      borderWidth: 1,
+      pointRadius: 0,
+      fill: true,
+      tension: 0.8,
+    })),
   };
+
   useEffect(() => {
     setTimeout(() => {
       setShouldRender(true);
@@ -179,35 +150,19 @@ const CoinBarGraph = ({
 }) => {
   const data = {
     labels: labelFormatter(coins[0].volumeLabels, days),
-    datasets: [
-      {
-        data: coins[0].total_volumes,
-        borderColor: "rgba(174, 139, 245)",
-        backgroundColor: "rgba(174, 139, 245)",
-        borderWidth: 8,
-        pointRadius: 0,
-        fill: true,
-        tension: 0.8,
-      },
-      {
-        data: coins[1]?.total_volumes,
-        borderColor: "rgba(255, 139, 245)",
-        backgroundColor: "rgba(255, 139, 245)",
-        borderWidth: 8,
-        pointRadius: 0,
-        fill: true,
-        tension: 0.8,
-      },
-      {
-        data: coins[2]?.total_volumes,
-        borderColor: "rgba(255, 255, 245)",
-        backgroundColor: "rgba(255, 255, 245)",
-        borderWidth: 8,
-        pointRadius: 0,
-        fill: true,
-        tension: 0.8,
-      },
-    ],
+    datasets: coins.map((coin, index) => ({
+      data: coin.total_volumes,
+      borderColor: options.plugins.tooltip.callbacks.labelColor({
+        datasetIndex: index,
+      }).backgroundColor,
+      backgroundColor: options.plugins.tooltip.callbacks.labelColor({
+        datasetIndex: index,
+      }).backgroundColor,
+      borderWidth: 8,
+      pointRadius: 0,
+      fill: true,
+      tension: 0.8,
+    })),
   };
 
   return <Bar options={options as any} data={data as any} />;
@@ -219,8 +174,6 @@ const CoinGraphChart = () => {
     (state) => state.selectedCoinData
   );
   const { currency, symbol } = useAppSelector((state) => state.currencySlice);
-  // const selectedCoin = selectedCoins.length > 0 ? selectedCoins[0] : null;
-
   const { coinMarketData } = useAppSelector((state) => state.coinMarketData);
 
   const selectedCoinsInfo: Coin[] = selectedCoins.reduce(
@@ -231,19 +184,15 @@ const CoinGraphChart = () => {
     []
   );
 
-  // console.log("selectedCoins:", selectedCoins);
-
-  const coinBG: string[] = ["bg-orange-300", "bg-[#7878FA]", "bg-[#D878FA]"];
+  const coinBG: string[] = ["bg-[#7878FA]", "bg-[#D878FA]", "bg-[#FDBA74]"];
 
   useEffect(() => {
-    if (selectedCoinsInfo.length > 0) {
-      return;
-    }
+    if (selectedCoinsInfo.length > 0) return;
     dispatch(
       getSelectedCoinData({
-        coinId: coinId,
-        timeDay: timeDay,
-        currency: currency,
+        coinId,
+        timeDay,
+        currency,
       })
     );
   }, [coinId, timeDay, currency]);

--- a/components/CoinGraphChart/index.tsx
+++ b/components/CoinGraphChart/index.tsx
@@ -52,7 +52,9 @@ const options = {
               ? value.toPrecision(7)
               : value.toFixed(2).toLocaleString();
           const coinName = tooltipItem.dataset.label;
-          return `${coinName}: ${formatNumber(value)}`;
+          return `${
+            coinName.charAt(0).toUpperCase() + coinName.slice(1).toLowerCase()
+          }: ${formatNumber(value)}`;
         },
         labelColor: function (tooltipItem: any) {
           const colors = [

--- a/components/CoinGraphChart/index.tsx
+++ b/components/CoinGraphChart/index.tsx
@@ -78,6 +78,9 @@ const options = {
         display: true,
         color: "grey",
         maxTicksLimit: 10,
+        font: {
+          size: 10,
+        },
         align: "inner",
       },
       border: { display: true },

--- a/components/CoinGraphChart/index.tsx
+++ b/components/CoinGraphChart/index.tsx
@@ -51,18 +51,19 @@ const options = {
             value < 10
               ? value.toPrecision(7)
               : value.toFixed(2).toLocaleString();
-          return formatNumber(value);
+          const coinName = tooltipItem.dataset.label;
+          return `${coinName}: ${formatNumber(value)}`;
         },
         labelColor: function (tooltipItem: any) {
           const colors = [
-            "rgba(174, 139, 245, 1)", // Color for the first coin
-            "rgba(255, 139, 245, 1)", // Color for the second coin
-            "rgba(253, 186, 116, 1)", // Color for the third coin
+            "rgba(174, 139, 245, 1)",
+            "rgba(255, 139, 245, 1)",
+            "rgba(253, 186, 116, 1)",
           ];
           return {
             borderRadius: 2,
             backgroundColor:
-              colors[tooltipItem.datasetIndex] || "rgba(159, 122, 234)",
+              colors[tooltipItem.datasetIndex] || "rgba(174, 139, 245, 1)",
           };
         },
       },
@@ -117,6 +118,7 @@ const CoinLineGraph = ({
     labels: labelFormatter(coins[0].priceLabels, days),
     datasets: coins.map((coin, index) => ({
       data: coin.prices,
+      label: coin.id,
       borderColor: options.plugins.tooltip.callbacks.labelColor({
         datasetIndex: index,
       }).backgroundColor,
@@ -152,6 +154,7 @@ const CoinBarGraph = ({
     labels: labelFormatter(coins[0].volumeLabels, days),
     datasets: coins.map((coin, index) => ({
       data: coin.total_volumes,
+      label: coin.id,
       borderColor: options.plugins.tooltip.callbacks.labelColor({
         datasetIndex: index,
       }).backgroundColor,

--- a/components/CoinGraphChart/index.tsx
+++ b/components/CoinGraphChart/index.tsx
@@ -10,6 +10,7 @@ import { SelectedCoin } from "@/interfaces/selectedcoin.interface";
 import { getSelectedCoinData } from "@/redux/features/selectedCoins";
 import { labelFormatter } from "@/redux/features/dateFormatter";
 import formatDateGraph from "@/utils/formatDateGraph";
+import backgroundColor from "@/utils/backgroundColour";
 import formatNumber from "@/utils/formatNumber";
 import { Line, Bar } from "react-chartjs-2";
 
@@ -22,7 +23,6 @@ import {
   Filler,
   BarElement,
   Tooltip,
-  ScriptableContext,
 } from "chart.js";
 
 ChartJS.register(
@@ -92,25 +92,6 @@ const options = {
   borderWidth: 0,
 };
 
-const getBackgroundColor = (
-  context: ScriptableContext<"line">
-): CanvasGradient => {
-  const ctx: CanvasRenderingContext2D = context.chart.ctx;
-  const height: number = ctx.canvas.clientHeight;
-  const gradientFill: CanvasGradient = ctx.createLinearGradient(
-    0,
-    0,
-    0,
-    height
-  );
-
-  gradientFill.addColorStop(0, "rgba(116, 116, 250, 0.4)");
-  gradientFill.addColorStop(0.7, "rgba(116, 116, 250, 0.1)");
-  gradientFill.addColorStop(1, "transparent");
-
-  return gradientFill;
-};
-
 const CoinLineGraph = ({
   coins,
   days,
@@ -127,7 +108,7 @@ const CoinLineGraph = ({
       borderColor: options.plugins.tooltip.callbacks.labelColor({
         datasetIndex: index,
       }).backgroundColor,
-      backgroundColor: getBackgroundColor,
+      backgroundColor: backgroundColor,
       borderWidth: 1,
       pointRadius: 0,
       fill: true,

--- a/components/CoinLineGraph/index.tsx
+++ b/components/CoinLineGraph/index.tsx
@@ -1,0 +1,102 @@
+import { SelectedCoin } from "@/interfaces/selectedcoin.interface";
+import { labelFormatter } from "@/redux/features/dateFormatter";
+import formatNumber from "@/utils/formatNumber";
+import backgroundColor from "@/utils/backgroundColour";
+import { useEffect, useState } from "react";
+import { Line } from "react-chartjs-2";
+
+const options = {
+  responsive: true,
+  tooltip: { enabled: true },
+  maintainAspectRatio: false,
+  plugins: {
+    tooltip: {
+      enabled: true,
+      mode: "index",
+      intersect: false,
+      callbacks: {
+        label: function (tooltipItem: any) {
+          let value = tooltipItem.dataset.data[tooltipItem.dataIndex];
+          value =
+            value < 10
+              ? value.toPrecision(7)
+              : value.toFixed(2).toLocaleString();
+          const coinName = tooltipItem.dataset.label;
+          return `${
+            coinName.charAt(0).toUpperCase() + coinName.slice(1).toLowerCase()
+          }: ${formatNumber(value)}`;
+        },
+        labelColor: function (tooltipItem: any) {
+          const colors = [
+            "rgba(174, 139, 245, 1)",
+            "rgba(255, 139, 245, 1)",
+            "rgba(253, 186, 116, 1)",
+          ];
+          return {
+            borderRadius: 2,
+            backgroundColor:
+              colors[tooltipItem.datasetIndex] || "rgba(174, 139, 245, 1)",
+          };
+        },
+      },
+    },
+  },
+  scales: {
+    x: {
+      grid: { display: false },
+      ticks: {
+        display: true,
+        color: "grey",
+        maxTicksLimit: 10,
+        font: {
+          size: 10,
+        },
+        align: "inner",
+      },
+      border: { display: true },
+      stacked: true,
+    },
+    y: { display: false },
+  },
+  pointRadius: 0,
+  borderWidth: 0,
+};
+
+const CoinLineGraph = ({
+  coins,
+  days,
+}: {
+  coins: SelectedCoin[];
+  days: string;
+}) => {
+  const [shouldRender, setShouldRender] = useState(false);
+  const data = {
+    labels: labelFormatter(coins[0].priceLabels, days),
+    datasets: coins.map((coin, index) => ({
+      data: coin.prices,
+      label: coin.id,
+      borderColor: options.plugins.tooltip.callbacks.labelColor({
+        datasetIndex: index,
+      }).backgroundColor,
+      backgroundColor: backgroundColor,
+      borderWidth: 1,
+      pointRadius: 0,
+      fill: true,
+      tension: 0.8,
+    })),
+  };
+
+  useEffect(() => {
+    setTimeout(() => {
+      setShouldRender(true);
+    }, 1000);
+  }, []);
+
+  return (
+    <div className="h-full w-full">
+      {shouldRender && <Line options={options as any} data={data} />}
+    </div>
+  );
+};
+
+export default CoinLineGraph;

--- a/components/MarketTableHeading/index.tsx
+++ b/components/MarketTableHeading/index.tsx
@@ -1,6 +1,6 @@
 const MarketTableHeading = () => {
   return (
-    <div className=" dark:bg-[#0d121d] bg-white w-full dark:text-[#DEDEDE] text-black text-sm font-light rounded-2xl p-5 flex gap-3 mb-2">
+    <div className=" dark:bg-black bg-white w-full dark:text-[#DEDEDE] text-black text-sm font-light rounded-2xl p-5 flex gap-3 mb-2">
       <span className="px-1">#</span>
       <span className="px-1 w-[16%]">Name</span>
       <span className="w-[6%] px-1">Price</span>

--- a/components/PriceCoinItem/index.tsx
+++ b/components/PriceCoinItem/index.tsx
@@ -44,7 +44,7 @@ const PriceCoinItem = ({ coin }: { coin: Coin }) => {
       className={`rounded-2xl pl-2 border-white bg-white ${
         isSelected
           ? "bg-gradient-to-r from-purple-400 to-orange-300 text-sm"
-          : "dark:bg-gray-900 dark:hover:bg-[#161f32] hover:bg-[#eaeaea]"
+          : "dark:bg-[#0d121d] dark:hover:bg-[#161f32] hover:bg-[#efefef]"
       } w-[190px] h-[60px] flex items-center flex-shrink-0`}
     >
       <div className="flex gap-3 items-center">
@@ -56,7 +56,7 @@ const PriceCoinItem = ({ coin }: { coin: Coin }) => {
         <div className="flex flex-col">
           <span
             className={`px-1 text-xs ${
-              isSelected ? "text-white" : "dark:text-[#c2c2c2] text-grey"
+              isSelected ? "text-white" : "dark:text-[#c2c2c2] text-grey "
             } flex`}
           >
             {coin.name.charAt(0).toUpperCase() +

--- a/components/RowCoinItem/index.tsx
+++ b/components/RowCoinItem/index.tsx
@@ -24,7 +24,7 @@ const RowCoinItem = ({ coin }: { coin: Coin }) => {
 
   return (
     <Link href={`/coin/${coin.id}`}>
-      <div className="dark:bg-[#0d121d] bg-white dark:hover:bg-[#121929] hover:bg-[#eaeaea] w-full dark:text-[#DEDEDE] text-black text-sm font-light rounded-3xl p-5 mb-2 flex gap-3 items-center">
+      <div className="dark:bg-[#0d121d] bg-white dark:hover:bg-[#121929] hover:bg-[#efefef] w-full dark:text-[#DEDEDE] text-black text-sm font-light rounded-3xl p-5 mb-2 flex gap-3 items-center">
         <span>{coin.market_cap_rank}</span>
         <Image src={coin.image} alt={coin.name} width={30} height={30} />
         <span className="w-[14%] px-1">

--- a/redux/features/selectedCoins.tsx
+++ b/redux/features/selectedCoins.tsx
@@ -37,7 +37,11 @@ export const getSelectedCoinData = createAsyncThunk(
       coinId,
       timeDay,
       currency,
-    }: { coinId: string; timeDay: string; currency: string },
+    }: {
+      coinId: string;
+      timeDay: string;
+      currency: string;
+    },
     { rejectWithValue }
   ) => {
     try {

--- a/utils/backgroundColour.tsx
+++ b/utils/backgroundColour.tsx
@@ -1,6 +1,6 @@
-import { Chart as ChartJS, ScriptableContext } from "chart.js";
+import { ScriptableContext } from "chart.js";
 
-const getBackgroundColor = (
+const backgroundColor = (
   context: ScriptableContext<"line">
 ): CanvasGradient => {
   const ctx: CanvasRenderingContext2D = context.chart.ctx;
@@ -16,3 +16,5 @@ const getBackgroundColor = (
   gradientFill.addColorStop(1, "transparent");
   return gradientFill;
 };
+
+export default backgroundColor;

--- a/utils/formatDateGraph.tsx
+++ b/utils/formatDateGraph.tsx
@@ -1,0 +1,7 @@
+const todayDate: string = new Date().toLocaleDateString("en-US", {
+  year: "numeric",
+  month: "long",
+  day: "numeric",
+});
+
+export default todayDate;


### PR DESCRIPTION
- user can now select up to three coins
- graph displays overlap of coin prices, when user selects more than one coin
- graph displays selected coin names and current prices
- tooltip colour assigned to coin background colour
- fixed bug with unnecessary re renderings of use effect
- refactored code to make it more readable